### PR TITLE
feat: Actions artifact for functions service SID sharing

### DIFF
--- a/.github/workflows/dev-deploy-serverless.yaml
+++ b/.github/workflows/dev-deploy-serverless.yaml
@@ -22,4 +22,13 @@ jobs:
           TWILIO_ACCOUNT_SID: ${{ secrets.TWILIO_ACCOUNT_SID }}
           TWILIO_API_KEY: ${{ secrets.TWILIO_API_KEY }}
           TWILIO_API_SECRET: ${{ secrets.TWILIO_API_SECRET }}
-        run: npm install -g twilio-cli && twilio plugins:install @twilio-labs/plugin-serverless && npm run deploy
+        run: npm install -g twilio-cli && twilio plugins:install @twilio-labs/plugin-serverless && npm run deploy > deploy-output.txt
+
+      - name: Save Service SID to file
+        run: grep -o -m1 '\ZS\w*' deploy-output.txt > service-sid.txt
+
+      - name: Save Service SID artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: service-sid
+          path: ./service-sid.txt

--- a/.github/workflows/dev-deploy-serverless.yaml
+++ b/.github/workflows/dev-deploy-serverless.yaml
@@ -28,7 +28,7 @@ jobs:
         run: grep -o -m1 '\ZS\w*' deploy-output.txt > service-sid.txt
 
       - name: Save Service SID artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: service-sid
           path: ./service-sid.txt

--- a/.github/workflows/prod-deploy-serverless.yaml
+++ b/.github/workflows/prod-deploy-serverless.yaml
@@ -17,10 +17,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Download artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: dev-deploy-serverless.yaml
+
       - name: Setup Twilio CLI and promote environment
         env:
           TWILIO_ACCOUNT_SID: ${{ secrets.TWILIO_ACCOUNT_SID }}
           TWILIO_API_KEY: ${{ secrets.TWILIO_API_KEY }}
           TWILIO_API_SECRET: ${{ secrets.TWILIO_API_SECRET }}
-          TWILIO_FUNCTIONS_SERVICE_SID: ${{ secrets.TWILIO_FUNCTIONS_SERVICE_SID }}
-        run: npm install -g twilio-cli && twilio plugins:install @twilio-labs/plugin-serverless && npm run promote
+        run: cat service-sid/service-sid.txt && export TWILIO_FUNCTIONS_SERVICE_SID=$(cat service-sid/service-sid.txt) && npm install -g twilio-cli && twilio plugins:install @twilio-labs/plugin-serverless && npm run promote

--- a/README.md
+++ b/README.md
@@ -14,18 +14,17 @@ This project is ready to be forked and developed upon for your Twilio functions 
 2. In **your** repository, head to _settings and secrets_.
 3. Create the following secrets:
 
-| Name                         | Description                                                                                                                                                                                                                                          | Required |
-| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| TWILIO_ACCOUNT_SID           | Account SID of the Twilio account to deploy to.                                                                                                                                                                                                      | Y        |
-| TWILIO_API_KEY               | API Key name used as authentication for deployment.                                                                                                                                                                                                  | Y        |
-| TWILIO_API_SECRET            | Secret associated to the above Twilio API Key.                                                                                                                                                                                                       | Y        |
-| TWILIO_FUNCTIONS_SERVICE_SID | SID of the functions service that should be promoted from dev to prod. **You won't have this SID until the dev deployment script has run for the first time and the functions service exists.** It is required for the production deployment script. | Y        |
+| Name               | Description                                         | Required |
+| ------------------ | --------------------------------------------------- | -------- |
+| TWILIO_ACCOUNT_SID | Account SID of the Twilio account to deploy to.     | Y        |
+| TWILIO_API_KEY     | API Key name used as authentication for deployment. | Y        |
+| TWILIO_API_SECRET  | Secret associated to the above Twilio API Key.      | Y        |
 
 4. Create `main` and `develop` branches. The `develop` will be the working branch and `main` will represent the latest production deployment. This will typically only be updated by pull requests from the `develop` branch.
 
 5. To Test the dev deployment script, push a commit to the `develop` branch.
 
-6. Assuming this has succeeded, update the GH secret with the functions service SID (see step 3) and apply any changes to the `main` branch to trigger the production deployment script.
+6. Assuming this has succeeded, apply any changes to the `main` branch to trigger the production deployment script.
 
 ## GitHub Actions
 
@@ -64,7 +63,7 @@ Push to `main` branch OR _workflow_dispatch_.
 | TWILIO_API_SECRET            | Secret associated to the above Twilio API Key.                                                                         | Y        |
 | TWILIO_FUNCTIONS_SERVICE_SID | SID of the functions service that should be promoted from dev to prod. Most likely this will be a prior dev deployment | Y        |
 
-This action will attempt to promote an existing functions service, matching the `TWILIO_FUNCTIONS_SERVICE_SID` environment variable. Moving it from a `dev` environment deployed in the dev action to a production environment instead.
+This action will attempt to promote an existing functions service, last deployed by the dev workflow run. Moving it from a `dev` environment to a production environment instead.
 
 ### Caveats
 


### PR DESCRIPTION
Development and production GH Actions now use artifacts to share the service SID of the deployed functions. This means updating the GH secrets to include the SID is no longer required and could often be easily missed.